### PR TITLE
Update multiple_buses.rst

### DIFF
--- a/messenger/multiple_buses.rst
+++ b/messenger/multiple_buses.rst
@@ -188,11 +188,11 @@ the correct tag:
                 <!-- command handlers -->
                 <prototype namespace="App\MessageHandler\" resource="%kernel.project_dir%/src/MessageHandler/*CommandHandler.php" autoconfigure="false">
                     <tag name="messenger.message_handler" bus="messenger.bus.commands"/>
-                </service>
+                </prototype>
                 <!-- query handlers -->
                 <prototype namespace="App\MessageHandler\" resource="%kernel.project_dir%/src/MessageHandler/*QueryHandler.php" autoconfigure="false">
                     <tag name="messenger.message_handler" bus="messenger.bus.queries"/>
-                </service>
+                </prototype>
             </services>
         </container>
 


### PR DESCRIPTION
The XML version of the example for automatically applying tags across a number of handlers via `resource:`  key was wrapped as `<prototype></service>`; Updated to `<prototype></prototype>` and confirmed that configuration works.

<!--

If your pull request fixes a BUG, use the oldest maintained branch that contains
the bug (see https://symfony.com/roadmap for the list of maintained branches).

If your pull request documents a NEW FEATURE, use the same Symfony branch where
the feature was introduced (and `master` for features of unreleased versions).

-->
